### PR TITLE
Sync target app features

### DIFF
--- a/build.go
+++ b/build.go
@@ -249,8 +249,7 @@ func targz() (*tarball, error) {
 	return &tarball{blob: archive, checksum: fmt.Sprintf("SHA256:%v", hex.EncodeToString(sha.Sum(nil)))}, nil
 }
 
-// TODO: Should App Features be synchronised? They could affect the build (e.g. by injecting additional env vars)
-// Should the dyno formation be explicitly set to 0?
+// TODO: Should the dyno formation be explicitly set to 0?
 func synchronise(ctx context.Context, h *heroku.Service, target, compile string) error {
 	bpi, err := h.BuildpackInstallationList(ctx, target, nil)
 	if err != nil {
@@ -298,10 +297,10 @@ func synchronise(ctx context.Context, h *heroku.Service, target, compile string)
 
 	for k, v := range targetAppFeatures {
 		if compileAppFeatures[k] != v {
-			// _, err := h.AppFeatureUpdate(ctx, compile, k, heroku.AppFeatureUpdateOpts{Enabled: v})
-			// if err != nil {
-			// 	return fmt.Errorf("updating compile app features: %w", err)
-			// }
+			_, err := h.AppFeatureUpdate(ctx, compile, k, heroku.AppFeatureUpdateOpts{Enabled: v})
+			if err != nil {
+				return fmt.Errorf("updating compile app features: %w", err)
+			}
 		}
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"regexp"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -246,6 +247,11 @@ func Test_BuildRelease(t *testing.T) {
 				t.Logf("%v missing on compile app", k)
 				t.Fail()
 
+				continue
+			}
+
+			// skip HEROKU_ env vars
+			if strings.HasPrefix(k, "HEROKU_") {
 				continue
 			}
 

--- a/main_test.go
+++ b/main_test.go
@@ -188,7 +188,7 @@ func withHarness(t *testing.T, fixture string, f func(*testing.T, string, string
 	f(t, production, compile, h)
 }
 
-func Test_Build(t *testing.T) {
+func Test_BuildRelease(t *testing.T) {
 	t.Parallel()
 
 	withHarness(t, "go-simple", func(t *testing.T, production, compile string, h *heroku.Service) {
@@ -214,10 +214,15 @@ func Test_Build(t *testing.T) {
 			t.Fail()
 		}
 
-		cmd := Cmd()
-		cmd.SetArgs([]string{"build", production, "--compiler", compile, "--verbose"})
+		buildCmd := Cmd()
+		buildCmd.SetArgs([]string{"build", production, "--compiler", compile, "--verbose"})
 
-		ok(t, cmd.ExecuteContext(context.Background()))
+		ok(t, buildCmd.ExecuteContext(context.Background()))
+
+		releaseCmd := Cmd()
+		releaseCmd.SetArgs([]string{"release", production, "--compiler", compile, "--verbose"})
+
+		ok(t, releaseCmd.ExecuteContext(context.Background()))
 
 		prodFeats := fetchFeats(t, h, production)
 		compileFeats := fetchFeats(t, h, compile)


### PR DESCRIPTION
Update the synchronisation logic to synchronise Heroku App Features.

This can be important as some Heroku App Features can set environment variables
during the build phase, which some builds might rely on.
