### PR TITLE
Detection failure should lead to compilation failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,14 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: 1.16.x
+    - uses: docker/setup-qemu-action@v1
+    - uses: docker/setup-buildx-action@v1
+    - uses: docker/build-push-action@v2
+      with:
+        context: .
+        tags: ghcr.io/cga1123/slugcmplr:testing
+        load: true
+        build-args: STACK=20
     - run: go get -v -d ./...
     - run: go test -race -timeout=10s -coverprofile=coverage.out -parallel=4 ./...
     - run: go tool cover -html=coverage.out -o coverage.html

--- a/compile.go
+++ b/compile.go
@@ -178,7 +178,7 @@ func compile(ctx context.Context, cmd Outputter, h *heroku.Service, buildDir, ca
 	return f.Close()
 }
 
-func compileCmd() *cobra.Command {
+func compileCmd(verbose bool) *cobra.Command {
 	var cacheDir, buildDir, image string
 	var local bool
 
@@ -187,6 +187,8 @@ func compileCmd() *cobra.Command {
 		Short: "compile the target applications",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			output := OutputterFromCmd(cmd, verbose)
+
 			if cacheDir == "" {
 				cd, err := os.MkdirTemp("", "")
 				if err != nil {
@@ -196,16 +198,16 @@ func compileCmd() *cobra.Command {
 				cacheDir = cd
 			}
 
-			dbg(cmd, "buildDir: %v", buildDir)
-			dbg(cmd, "cacheDir: %v", cacheDir)
+			dbg(output, "buildDir: %v", buildDir)
+			dbg(output, "cacheDir: %v", cacheDir)
 
 			if local {
-				client, err := netrcClient(cmd)
+				client, err := netrcClient(output)
 				if err != nil {
 					return err
 				}
 
-				return compile(cmd.Context(), cmd, client, buildDir, cacheDir)
+				return compile(cmd.Context(), output, client, buildDir, cacheDir)
 			}
 
 			netrcpath, err := netrcPath()
@@ -213,7 +215,7 @@ func compileCmd() *cobra.Command {
 				return fmt.Errorf("failed to find netrc path: %w", err)
 			}
 
-			return bootstrapDocker(cmd.Context(), cmd, buildDir, cacheDir, netrcpath, image)
+			return bootstrapDocker(cmd.Context(), output, buildDir, cacheDir, netrcpath, image)
 		},
 	}
 

--- a/compile.go
+++ b/compile.go
@@ -24,9 +24,9 @@ type Compile struct {
 	Buildpacks    []*buildpack.Buildpack `json:"buildpacks"`
 }
 
-func bootstrapDocker(ctx context.Context, buildDir, cacheDir, netrc, image string) error {
-	step(os.Stdout, "Reading metadata")
-	log(os.Stdout, "From: %v", filepath.Join(buildDir, "meta.json"))
+func bootstrapDocker(ctx context.Context, cmd Outputter, buildDir, cacheDir, netrc, image string) error {
+	step(cmd, "Reading metadata")
+	log(cmd, "From: %v", filepath.Join(buildDir, "meta.json"))
 
 	m, err := os.Open(filepath.Join(buildDir, "meta.json"))
 	if err != nil {
@@ -41,7 +41,7 @@ func bootstrapDocker(ctx context.Context, buildDir, cacheDir, netrc, image strin
 
 	imageName := strings.ReplaceAll(image, "%stack%", c.Stack)
 
-	log(os.Stdout, "Using: %v", imageName)
+	log(cmd, "Using: %v", imageName)
 
 	dockerRun := exec.CommandContext(ctx, "docker", "run",
 		"--volume", fmt.Sprintf("%v:/tmp/build", buildDir),
@@ -55,16 +55,16 @@ func bootstrapDocker(ctx context.Context, buildDir, cacheDir, netrc, image strin
 		"--cache-dir", "/tmp/cache",
 	) // #nosec G204
 
-	dbg(os.Stdout, "dockerRun: %v", dockerRun.String())
+	dbg(cmd, "dockerRun: %v", dockerRun.String())
 
-	dockerRun.Stderr, dockerRun.Stdout = os.Stderr, os.Stdout
+	dockerRun.Stderr, dockerRun.Stdout = cmd.ErrOrStderr(), cmd.OutOrStdout()
 
 	return dockerRun.Run()
 }
 
-func compile(ctx context.Context, h *heroku.Service, buildDir, cacheDir string) error {
-	step(os.Stdout, "Reading metadata")
-	log(os.Stdout, "From: %v", filepath.Join(buildDir, "meta.json"))
+func compile(ctx context.Context, cmd Outputter, h *heroku.Service, buildDir, cacheDir string) error {
+	step(cmd, "Reading metadata")
+	log(cmd, "From: %v", filepath.Join(buildDir, "meta.json"))
 
 	m, err := os.Open(filepath.Join(buildDir, "meta.json"))
 	if err != nil {
@@ -77,15 +77,17 @@ func compile(ctx context.Context, h *heroku.Service, buildDir, cacheDir string) 
 		return fmt.Errorf("failed to decode metadata: %w", err)
 	}
 
-	log(os.Stdout, "application: %v", c.Application)
-	log(os.Stdout, "stack: %v", c.Stack)
-	log(os.Stdout, "buildpacks: %v", len(c.Buildpacks))
+	log(cmd, "application: %v", c.Application)
+	log(cmd, "stack: %v", c.Stack)
+	log(cmd, "buildpacks: %v", len(c.Buildpacks))
 
 	build := &buildpack.Build{
 		CacheDir:      cacheDir,
 		BuildDir:      buildDir,
 		Stack:         c.Stack,
 		SourceVersion: c.SourceVersion,
+		Stdout:        cmd.OutOrStdout(),
+		Stderr:        cmd.ErrOrStderr(),
 	}
 
 	previousBuildpacks := make([]*buildpack.Buildpack, 0, len(c.Buildpacks))
@@ -98,13 +100,13 @@ func compile(ctx context.Context, h *heroku.Service, buildDir, cacheDir string) 
 			return err
 		}
 		if !ok {
-			step(os.Stdout, "App not compatible with buildpack: %v", bp.URL)
-			wrn(os.Stdout, "Compilation failed")
+			step(cmd, "App not compatible with buildpack: %v", bp.URL)
+			wrn(cmd, "Compilation failed")
 
 			return fmt.Errorf("buildpack detection failure")
 		}
 
-		step(os.Stdout, "%v app detected", detected)
+		step(cmd, "%v app detected", detected)
 
 		if err := bp.Compile(ctx, previousBuildpacks, build); err != nil {
 			return err
@@ -116,7 +118,7 @@ func compile(ctx context.Context, h *heroku.Service, buildDir, cacheDir string) 
 	appDir := filepath.Join(buildDir, buildpack.AppDir)
 
 	// read Procfile
-	step(os.Stdout, "Discovering process types")
+	step(cmd, "Discovering process types")
 
 	pf, err := os.Open(filepath.Join(appDir, "Procfile"))
 	if err != nil {
@@ -130,7 +132,7 @@ func compile(ctx context.Context, h *heroku.Service, buildDir, cacheDir string) 
 	}
 
 	// tar up
-	step(os.Stdout, "Compressing...")
+	step(cmd, "Compressing...")
 
 	tarball, err := targz(appDir, filepath.Join(buildDir, "app.tgz"))
 	if err != nil {
@@ -161,8 +163,8 @@ func compile(ctx context.Context, h *heroku.Service, buildDir, cacheDir string) 
 		Commit:      c.SourceVersion,
 	}
 
-	step(os.Stdout, "Writing metadata")
-	log(os.Stdout, "To: %v", filepath.Join(buildDir, "release.json"))
+	step(cmd, "Writing metadata")
+	log(cmd, "To: %v", filepath.Join(buildDir, "release.json"))
 	f, err := os.Create(filepath.Join(buildDir, "release.json"))
 	if err != nil {
 		return fmt.Errorf("failed to create meta file: %w", err)
@@ -194,16 +196,16 @@ func compileCmd() *cobra.Command {
 				cacheDir = cd
 			}
 
-			dbg(os.Stdout, "buildDir: %v", buildDir)
-			dbg(os.Stdout, "cacheDir: %v", cacheDir)
+			dbg(cmd, "buildDir: %v", buildDir)
+			dbg(cmd, "cacheDir: %v", cacheDir)
 
 			if local {
-				client, err := netrcClient()
+				client, err := netrcClient(cmd)
 				if err != nil {
 					return err
 				}
 
-				return compile(cmd.Context(), client, buildDir, cacheDir)
+				return compile(cmd.Context(), cmd, client, buildDir, cacheDir)
 			}
 
 			netrcpath, err := netrcPath()
@@ -211,7 +213,7 @@ func compileCmd() *cobra.Command {
 				return fmt.Errorf("failed to find netrc path: %w", err)
 			}
 
-			return bootstrapDocker(cmd.Context(), buildDir, cacheDir, netrcpath, image)
+			return bootstrapDocker(cmd.Context(), cmd, buildDir, cacheDir, netrcpath, image)
 		},
 	}
 

--- a/compile.go
+++ b/compile.go
@@ -98,7 +98,10 @@ func compile(ctx context.Context, h *heroku.Service, buildDir, cacheDir string) 
 			return err
 		}
 		if !ok {
-			continue
+			step(os.Stdout, "App not compatible with buildpack: %v", bp.URL)
+			wrn(os.Stdout, "Compilation failed")
+
+			return fmt.Errorf("buildpack detection failure")
 		}
 
 		step(os.Stdout, "%v app detected", detected)

--- a/main.go
+++ b/main.go
@@ -37,8 +37,10 @@ func main() {
 
 func Cmd() *cobra.Command {
 	rootCmd := &cobra.Command{
-		Use:   "slugcmplr",
-		Short: "slugcmplr helps you detach building and releasing Heroku applications",
+		Use:           "slugcmplr",
+		Short:         "slugcmplr helps you detach building and releasing Heroku applications",
+		SilenceUsage:  true,
+		SilenceErrors: true,
 	}
 
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")

--- a/main.go
+++ b/main.go
@@ -52,52 +52,57 @@ func Cmd() *cobra.Command {
 	return rootCmd
 }
 
-func step(w io.Writer, format string, a ...interface{}) {
-	fmt.Fprintf(w, "-----> %s\n", fmt.Sprintf(format, a...))
+type Outputter interface {
+	OutOrStdout() io.Writer
+	ErrOrStderr() io.Writer
 }
 
-func log(w io.Writer, format string, a ...interface{}) {
-	fmt.Fprintf(w, "       %s\n", fmt.Sprintf(format, a...))
+func step(cmd Outputter, format string, a ...interface{}) {
+	fmt.Fprintf(cmd.OutOrStdout(), "-----> %s\n", fmt.Sprintf(format, a...))
 }
 
-func wrn(w io.Writer, format string, a ...interface{}) {
-	fmt.Fprintf(w, " !!    %s\n", fmt.Sprintf(format, a...))
+func log(cmd Outputter, format string, a ...interface{}) {
+	fmt.Fprintf(cmd.OutOrStdout(), "       %s\n", fmt.Sprintf(format, a...))
 }
 
-func dbg(w io.Writer, format string, a ...interface{}) {
+func wrn(cmd Outputter, format string, a ...interface{}) {
+	fmt.Fprintf(cmd.ErrOrStderr(), " !!    %s\n", fmt.Sprintf(format, a...))
+}
+
+func dbg(cmd Outputter, format string, a ...interface{}) {
 	if verbose {
-		log(w, format, a...)
+		log(cmd, format, a...)
 	}
 }
 
-func commitDir(dir string) (string, error) {
-	step(os.Stdout, "Fetching HEAD commit...")
+func commitDir(cmd Outputter, dir string) (string, error) {
+	step(cmd, "Fetching HEAD commit...")
 	r, err := git.PlainOpenWithOptions(dir, &git.PlainOpenOptions{DetectDotGit: true})
 	if err != nil {
-		wrn(os.Stderr, "error detecting HEAD commit: %v", err)
+		wrn(cmd, "error detecting HEAD commit: %v", err)
 		return "", err
 	}
 
 	hsh, err := r.ResolveRevision(plumbing.Revision("HEAD"))
 	if err != nil {
-		wrn(os.Stderr, "error detecting HEAD commit: %v", err)
+		wrn(cmd, "error detecting HEAD commit: %v", err)
 		return "", err
 	}
 
 	return hsh.String(), nil
 }
 
-func netrcClient() (*heroku.Service, error) {
-	step(os.Stdout, "Building client from .netrc...")
+func netrcClient(cmd Outputter) (*heroku.Service, error) {
+	step(cmd, "Building client from .netrc...")
 	netrcpath, err := netrcPath()
 	if err != nil {
-		wrn(os.Stderr, "error finding .netrc file path: %v", err)
+		wrn(cmd, "error finding .netrc file path: %v", err)
 		return nil, err
 	}
 
 	rcfile, err := netrc.ParseFile(netrcpath)
 	if err != nil {
-		wrn(os.Stderr, "error creating client from .netrc: %v", err)
+		wrn(cmd, "error creating client from .netrc: %v", err)
 		return nil, err
 	}
 
@@ -257,11 +262,11 @@ func upload(ctx context.Context, method, url, path string) error {
 	return nil
 }
 
-func outputStream(out io.Writer, stream string) error {
-	return outputStreamAttempt(out, stream, 0)
+func outputStream(cmd Outputter, out io.Writer, stream string) error {
+	return outputStreamAttempt(cmd, out, stream, 0)
 }
 
-func outputStreamAttempt(out io.Writer, stream string, attempt int) error {
+func outputStreamAttempt(cmd Outputter, out io.Writer, stream string, attempt int) error {
 	if attempt >= 5 {
 		return fmt.Errorf("failed to fetch outputStream after 5 attempts")
 	}
@@ -274,10 +279,10 @@ func outputStreamAttempt(out io.Writer, stream string, attempt int) error {
 
 	if resp.StatusCode > 399 {
 		if resp.StatusCode == 404 {
-			log(os.Stdout, "Output stream 404, likely the process is still starting up. Trying again in 2s...")
+			log(cmd, "Output stream 404, likely the process is still starting up. Trying again in 2s...")
 			time.Sleep(2 * time.Second)
 
-			return outputStreamAttempt(out, stream, attempt+1)
+			return outputStreamAttempt(cmd, out, stream, attempt+1)
 		}
 
 		return fmt.Errorf("output stream returned HTTP status: %v", resp.Status)
@@ -289,4 +294,25 @@ func outputStreamAttempt(out io.Writer, stream string, attempt int) error {
 	}
 
 	return scn.Err()
+}
+
+type outputter struct {
+	Out io.Writer
+	Err io.Writer
+}
+
+func (o *outputter) OutOrStdout() io.Writer {
+	if o.Out == nil {
+		return os.Stdout
+	}
+
+	return o.Out
+}
+
+func (o *outputter) ErrOrStderr() io.Writer {
+	if o.Err == nil {
+		return os.Stdout
+	}
+
+	return o.Err
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,10 +22,10 @@ func Test_Suite(t *testing.T) {
 	// nolint: paralleltest
 	t.Run("End to end tests", func(t *testing.T) {
 		t.Run("TestDetectFail", testDetectFail)
-		t.Run("TestPrepare", testPrepare)
-		t.Run("TestGo", testGo)
-		t.Run("TestRails", testRails)
-		t.Run("TestBinary", testBinary)
+		// t.Run("TestPrepare", testPrepare)
+		// t.Run("TestGo", testGo)
+		// t.Run("TestRails", testRails)
+		// t.Run("TestBinary", testBinary)
 	})
 }
 
@@ -121,59 +121,33 @@ func testPrepare(t *testing.T) {
 }
 
 func testDetectFail(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
-	// TODO: can't run this in parallel, because we're messing
-	// with package level vars (os.Stdout) causing data-races across
-	// goroutines!
-	//
-	// Really need to suck it up and inject an io.Writer for stderr/stdout
-	// Can use these in combination?
-	// - https://pkg.go.dev/github.com/spf13/cobra#Command.SetOut
-	// - https://pkg.go.dev/github.com/spf13/cobra#Command.OutOrStdout
-	// - https://pkg.go.dev/github.com/spf13/cobra#Command.OutOrStderr
+	buildpacks := []*BuildpackDescription{
+		{URL: "https://github.com/CGA1123/heroku-buildpack-bar", Name: "CGA1123/heroku-buildpack-bar"},
+		{URL: "https://github.com/CGA1123/heroku-buildpack-detect-fail", Name: "CGA1123/heroku-buildpack-detect-fail"},
+		{URL: "https://github.com/CGA1123/heroku-buildpack-foo", Name: "CGA1123/heroku-buildpack-foo"},
+	}
 
-	// TODO: we don't need a full harness here, we can skip the heroku parts and inject the required, stack, config vars, and buildpacks
-	// maybe there's a mising withStubHarness function?
-	withHarness(t, "CGA1123/slugcmplr-fixture-binary", func(t *testing.T, app, src string, h *heroku.Service) {
-		pattn := strings.ReplaceAll("CGA1123/slugcmplr-fixture-binary", "/", "__") + "_"
-		buildDir, err := os.MkdirTemp("", pattn)
-		if err != nil {
-			t.Fatalf("failed to create build director: %v", err)
-		}
-		defer os.RemoveAll(buildDir)
+	configVars := map[string]string{"FOO": "BAR", "BAR": "FOO"}
 
-		if _, err := h.BuildpackInstallationUpdate(context.Background(), app, heroku.BuildpackInstallationUpdateOpts{
-			Updates: []struct {
-				Buildpack string `json:"buildpack" url:"buildpack,key"`
-			}{
-				{Buildpack: "https://github.com/CGA1123/heroku-buildpack-bar"},
-				{Buildpack: "https://github.com/CGA1123/heroku-buildpack-detect-fail"},
-				{Buildpack: "https://github.com/CGA1123/heroku-buildpack-foo"},
-			},
-		}); err != nil {
-			t.Fatalf("failed to update buildpacks: %v", err)
-		}
-
-		// Prepare
-		prepareCmd := Cmd()
-		prepareCmd.SetArgs([]string{
-			"prepare", app,
-			"--build-dir", buildDir,
-			"--source-dir", src})
-		ok(t, prepareCmd.Execute())
-
+	withStubPrepare(t, "CGA1123/slugcmplr-fixture-binary", buildpacks, configVars, func(t *testing.T, app, buildDir string) {
 		var compileErr error
-		logs := withCapturedStdOut(t, func() {
-			// Compile
-			compileCmd := Cmd()
-			compileCmd.SetArgs([]string{
-				"compile",
-				"--build-dir", buildDir,
-				"--image", "ghcr.io/cga1123/slugcmplr:testing"})
+		// Compile
+		logBuilder := &strings.Builder{}
+		writer := io.MultiWriter(logBuilder, os.Stdout)
 
-			compileErr = compileCmd.Execute()
-		})
+		compileCmd := Cmd()
+		compileCmd.SetOut(writer)
+		compileCmd.SetErr(writer)
+		compileCmd.SetArgs([]string{
+			"compile",
+			"--build-dir", buildDir,
+			"--image", "ghcr.io/cga1123/slugcmplr:testing"})
+
+		compileErr = compileCmd.Execute()
+
+		logs := logBuilder.String()
 
 		if strings.Contains(logs, "Found BAR exported") {
 			t.Fatalf("expected logs not to contain evidence of running heroku-buildpack-foo")

--- a/main_test.go
+++ b/main_test.go
@@ -22,10 +22,10 @@ func Test_Suite(t *testing.T) {
 	// nolint: paralleltest
 	t.Run("End to end tests", func(t *testing.T) {
 		t.Run("TestDetectFail", testDetectFail)
-		// t.Run("TestPrepare", testPrepare)
-		// t.Run("TestGo", testGo)
-		// t.Run("TestRails", testRails)
-		// t.Run("TestBinary", testBinary)
+		t.Run("TestPrepare", testPrepare)
+		t.Run("TestGo", testGo)
+		t.Run("TestRails", testRails)
+		t.Run("TestBinary", testBinary)
 	})
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -121,7 +121,17 @@ func testPrepare(t *testing.T) {
 }
 
 func testDetectFail(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
+
+	// TODO: can't run this in parallel, because we're messing
+	// with package level vars (os.Stdout) causing data-races across
+	// goroutines!
+	//
+	// Really need to suck it up and inject an io.Writer for stderr/stdout
+	// Can use these in combination?
+	// - https://pkg.go.dev/github.com/spf13/cobra#Command.SetOut
+	// - https://pkg.go.dev/github.com/spf13/cobra#Command.OutOrStdout
+	// - https://pkg.go.dev/github.com/spf13/cobra#Command.OutOrStderr
 
 	// TODO: we don't need a full harness here, we can skip the heroku parts and inject the required, stack, config vars, and buildpacks
 	// maybe there's a mising withStubHarness function?

--- a/prepare.go
+++ b/prepare.go
@@ -127,7 +127,7 @@ func prepare(ctx context.Context, cmd Outputter, p *Prepare) error {
 	return f.Close()
 }
 
-func prepareCmd() *cobra.Command {
+func prepareCmd(verbose bool) *cobra.Command {
 	var buildDir, srcDir string
 
 	cmd := &cobra.Command{
@@ -136,7 +136,8 @@ func prepareCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			application := args[0]
-			h, err := netrcClient(cmd)
+			output := OutputterFromCmd(cmd, verbose)
+			h, err := netrcClient(output)
 			if err != nil {
 				return err
 			}
@@ -159,9 +160,9 @@ func prepareCmd() *cobra.Command {
 				srcDir = sd
 			}
 
-			dbg(cmd, "buildDir: %v", buildDir)
-			dbg(cmd, "srcDir: %v", srcDir)
-			dbg(cmd, "application: %v", application)
+			dbg(output, "buildDir: %v", buildDir)
+			dbg(output, "srcDir: %v", srcDir)
+			dbg(output, "application: %v", application)
 
 			ctx := cmd.Context()
 
@@ -200,7 +201,7 @@ func prepareCmd() *cobra.Command {
 				}
 			}
 
-			return prepare(ctx, cmd, &Prepare{
+			return prepare(ctx, output, &Prepare{
 				ApplicationName: application,
 				Stack:           app.Stack.Name,
 				ConfigVars:      configVars,

--- a/release.go
+++ b/release.go
@@ -81,19 +81,20 @@ func release(ctx context.Context, cmd Outputter, h *heroku.Service, buildDir, ap
 	return fmt.Errorf("release still pending after multiple attempts")
 }
 
-func releaseCmd() *cobra.Command {
+func releaseCmd(verbose bool) *cobra.Command {
 	var buildDir, application string
 	cmd := &cobra.Command{
 		Use:   "release",
 		Short: "release a slug",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := netrcClient(cmd)
+			output := OutputterFromCmd(cmd, verbose)
+			client, err := netrcClient(output)
 			if err != nil {
 				return err
 			}
 
-			return release(cmd.Context(), cmd, client, buildDir, application)
+			return release(cmd.Context(), output, client, buildDir, application)
 		},
 	}
 

--- a/test_helper.go
+++ b/test_helper.go
@@ -199,6 +199,8 @@ func withHarness(t *testing.T, fixture string, f func(*testing.T, string, string
 }
 
 func withStubPrepare(t *testing.T, fixture string, buildpacks []*BuildpackDescription, configVars map[string]string, f func(*testing.T, string, string)) {
+	acceptance(t)
+
 	srcdir, err := os.MkdirTemp("", strings.ReplaceAll(fixture, "/", "__")+"_")
 	if err != nil {
 		t.Fatalf("failed to create tempdir: %v", err)


### PR DESCRIPTION
This causes the compilation to halt and fail if any configured buildpack
finds that the application is not compatible with it.

Closes: #15