### PR TITLE
Delay creating symlinks until after all regular files

### DIFF
--- a/scripts/test-acceptance
+++ b/scripts/test-acceptance
@@ -7,8 +7,12 @@ if [[ -z ${SLUGCMPLR_ACC_HEROKU_PASS} ]] || [[ -z ${SLUGCMPLR_ACC_HEROKU_EMAIL} 
 fi
 
 echo "These tests will create resources in your Heroku account (${SLUGCMPLR_ACC_HEROKU_EMAIL})."
-echo "Are you sure? (Press any key to continue)"
 
-read
+read -n 1 -s -r -p "Are you sure? (Press any key to continue)"; echo
 
-SLUGCMPLR_ACC=true go test -v ./...
+echo "Running..."
+
+export SLUGCMPLR_ACC="true"
+
+go get -v -d
+go test -v -race -parallel=4 ./...


### PR DESCRIPTION
When decompressing a tarball there isn't any guarantee of the order
which tar headers are presented to us by (*tar.Reader).Next(), this
means that it's possible for us to evaluate and try to create a symlink
before the file which it points to has been created.

This is usually fine, a symlink isn't required to point to anything.
However, for security reasons (mitigating against "Zip-slip") we wan't
to evaluate that a symlink resolves to a file that is within the
expected directory (i.e. it should not escape outside of the directory
which we are decompressing into).

For this reason, we need to collect all symlinks and process them after
we've gone through all regular files.

There might still be a chance of problems being caused by symlinks that
point to other symlinks -- I'll cross that bridge if I get to it.