### PR TITLE
Add `slugcmplr image` subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,21 @@ different from the one you build from. This will work as long as the
 applications are in the same Heroku team. (This is becuase the slug must be
 accessible to the application).
 
+#### `image --build-dir [BUILD-DIR] --cmd [CMD]`
+
+The `image` subcommand builds a container image using `docker build`. By
+default it uses a Heroku Stack Image (e.g. `heroku/heroku:20`) that is
+compatible with your application.
+
+You can optionally pass `--image [IMAGE]` to use a custom base image. You can
+use the `%stack%` pattern in `IMAGE` to have a stack _number_ (e.g. `20`) as
+part of the image name or tag.
+
+The image is build by copying the contents of your application after building
+into `/app`.
+
+The `CMD` is the command that Heroku will use in its container runtime to start
+your application. (e.g. `bundle exec puma -p $PORT`, `bin/server --port $PORT`).
 
 ## Authentication
 

--- a/image.go
+++ b/image.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/cga1123/slugcmplr/buildpack"
+	"github.com/spf13/cobra"
+)
+
+const dockerfileTemplate = `FROM {{.BaseImage}}
+RUN groupadd -r dyno && useradd --no-log-init -r -g dyno u1123
+WORKDIR /app
+COPY {{.AppDirectory}} /app
+RUN chown -R u1123:dyno /app
+USER u1123
+
+CMD {{.Command}}
+`
+
+type templateVars struct {
+	BaseImage    string
+	AppDirectory string
+	Command      string
+}
+
+func image(ctx context.Context, out Outputter, buildDir, image, cmd string) error {
+	m, err := os.Open(filepath.Join(buildDir, "meta.json"))
+	if err != nil {
+		return fmt.Errorf("failed to read metadata: %w", err)
+	}
+	defer m.Close()
+
+	c := &Compile{}
+	if err := json.NewDecoder(m).Decode(c); err != nil {
+		return fmt.Errorf("failed to decode metadata: %w", err)
+	}
+
+	t, err := template.New("").Parse(dockerfileTemplate)
+	if err != nil {
+		return fmt.Errorf("failed to build Dockerfile template: %w", err)
+	}
+
+	f, err := os.Create(filepath.Join(buildDir, "Dockerfile"))
+	if err != nil {
+		return fmt.Errorf("failed to create Dockerfile: %w", err)
+	}
+	defer f.Close()
+
+	if err := t.Execute(f, templateVars{
+		BaseImage:    strings.ReplaceAll(image, "%stack%", strings.TrimPrefix(c.Stack, "heroku-")),
+		AppDirectory: buildpack.AppDir,
+		Command:      cmd,
+	}); err != nil {
+		return fmt.Errorf("failed to execute Dockerfile template: %w", err)
+	}
+
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("failed to create Dockerfile: %w", err)
+	}
+
+	dockerBuild := exec.CommandContext(ctx, "docker", "build",
+		"--quiet",
+		"--file", filepath.Join(buildDir, "Dockerfile"),
+		buildDir,
+	) // #nosec G204
+	dockerBuild.Stderr, dockerBuild.Stdout = out.ErrOrStderr(), out.OutOrStdout()
+
+	return dockerBuild.Run()
+}
+
+func imageCmd(verbose bool) *cobra.Command {
+	var buildDir, img, command string
+
+	cmd := &cobra.Command{
+		Use:   "image",
+		Short: "build a container from your compiled application",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			output := OutputterFromCmd(cmd, verbose)
+
+			dbg(output, "buildDir: %v", buildDir)
+
+			return image(cmd.Context(), output, buildDir, img, command)
+		},
+	}
+
+	cmd.Flags().StringVar(&buildDir, "build-dir", "", "The build directory")
+	cmd.MarkFlagRequired("build-dir") // nolint:errcheck
+
+	cmd.Flags().StringVar(&command, "cmd", "", "The command (CMD) to run by default")
+	cmd.MarkFlagRequired("cmd") // nolint:errcheck
+
+	cmd.Flags().StringVar(&img, "image", "heroku/heroku:%stack%", "Override docker image to use, include %stack% in order to substitute the stack number")
+
+	return cmd
+}

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ import (
 func main() {
 	cmd := Cmd()
 	if err := cmd.ExecuteContext(context.Background()); err != nil {
+		fmt.Printf("error: %v\n", err)
 		os.Exit(1)
 	}
 }
@@ -46,6 +47,7 @@ func Cmd() *cobra.Command {
 	rootCmd.AddCommand(prepareCmd(verbose))
 	rootCmd.AddCommand(compileCmd(verbose))
 	rootCmd.AddCommand(releaseCmd(verbose))
+	rootCmd.AddCommand(imageCmd(verbose))
 
 	return rootCmd
 }

--- a/release.go
+++ b/release.go
@@ -18,9 +18,9 @@ type Release struct {
 	Commit      string `json:"commit"`
 }
 
-func release(ctx context.Context, cmd Outputter, h *heroku.Service, buildDir, application string) error {
-	step(cmd, "Reading release")
-	log(cmd, "From: %v", filepath.Join(buildDir, "release.json"))
+func release(ctx context.Context, out Outputter, h *heroku.Service, buildDir, application string) error {
+	step(out, "Reading release")
+	log(out, "From: %v", filepath.Join(buildDir, "release.json"))
 
 	rf, err := os.Open(filepath.Join(buildDir, "release.json"))
 	if err != nil {
@@ -37,10 +37,10 @@ func release(ctx context.Context, cmd Outputter, h *heroku.Service, buildDir, ap
 		application = r.Application
 	}
 
-	log(cmd, "application: %v", application)
-	log(cmd, "slug: %v", r.Slug)
+	log(out, "application: %v", application)
+	log(out, "slug: %v", r.Slug)
 
-	step(cmd, "Releasing slug %v to %v", r.Slug, r.Application)
+	step(out, "Releasing slug %v to %v", r.Slug, r.Application)
 
 	release, err := h.ReleaseCreate(ctx, application, heroku.ReleaseCreateOpts{
 		Slug:        r.Slug,
@@ -51,20 +51,20 @@ func release(ctx context.Context, cmd Outputter, h *heroku.Service, buildDir, ap
 	}
 
 	if release.OutputStreamURL != nil {
-		if err := outputStream(cmd, os.Stdout, *release.OutputStreamURL); err != nil {
+		if err := outputStream(out, os.Stdout, *release.OutputStreamURL); err != nil {
 			return fmt.Errorf("failed to stream output: %w", err)
 		}
 	}
 
 	for i := 0; i < 36; i++ {
-		log(cmd, "checking release status... (attempt %v)", i+1)
+		log(out, "checking release status... (attempt %v)", i+1)
 
 		info, err := h.ReleaseInfo(ctx, r.Application, release.ID)
 		if err != nil {
 			return fmt.Errorf("failed to fetch release info: %w", err)
 		}
 
-		log(cmd, "status: %v", info.Status)
+		log(out, "status: %v", info.Status)
 
 		switch info.Status {
 		case "failed":


### PR DESCRIPTION
`slugcmplr image` builds a Docker image using (by default) the Heroku Stack
Image matching your applications current stack (e.g. `heroku/heroku:20`).

You can pass the command to run by default with the `--cmd` flag.

The base image to build from can be overwritten with the `--image` flag.

The built image is untagged (at the moment). `image` will output the build
image ID to stdout.


Closes: #22 