### PR TITLE
Add --process option to `slugcmplr image`

### DIFF
--- a/cmd/slugcmplr/main_test.go
+++ b/cmd/slugcmplr/main_test.go
@@ -34,6 +34,78 @@ func Test_Suite(t *testing.T) {
 	})
 }
 
+func Test_Image_WithProcess(t *testing.T) {
+	t.Parallel()
+
+	buildpacks := []*slugcmplr.BuildpackReference{
+		{URL: "https://github.com/CGA1123/heroku-buildpack-bar", Name: "CGA1123/heroku-buildpack-bar"},
+	}
+
+	configVars := map[string]string{"FOO": "BAR", "BAR": "FOO"}
+
+	withStubPrepare(t, "CGA1123/slugcmplr-fixture-binary", buildpacks, configVars, func(t *testing.T, app, buildDir string) {
+		imageCmd := Cmd()
+		imageCmd.SetArgs([]string{
+			"image",
+			"--build-dir", buildDir,
+			"--image", "test-image:%stack%",
+			"--process", "web",
+			"--no-build",
+		})
+
+		ok(t, imageCmd.Execute())
+
+		b, err := os.ReadFile(filepath.Join(buildDir, "Dockerfile"))
+		ok(t, err)
+
+		dockerfile := string(b)
+
+		if !strings.HasPrefix(dockerfile, "FROM test-image:heroku-20") {
+			t.Fatalf("expected dockerfile to start with expected base image")
+		}
+
+		if !strings.HasSuffix(dockerfile, "CMD ./server\n") {
+			t.Fatalf("expected dockerfile to end with expected CMD from procfile")
+		}
+	})
+}
+
+func Test_Image_WithCmd(t *testing.T) {
+	t.Parallel()
+
+	buildpacks := []*slugcmplr.BuildpackReference{
+		{URL: "https://github.com/CGA1123/heroku-buildpack-bar", Name: "CGA1123/heroku-buildpack-bar"},
+	}
+
+	configVars := map[string]string{"FOO": "BAR", "BAR": "FOO"}
+
+	withStubPrepare(t, "CGA1123/slugcmplr-fixture-binary", buildpacks, configVars, func(t *testing.T, app, buildDir string) {
+		imageCmd := Cmd()
+		imageCmd.SetArgs([]string{
+			"image",
+			"--build-dir", buildDir,
+			"--image", "test-image:%stack%",
+			"--cmd", "bundle exec puma",
+			"--no-build",
+		})
+
+		ok(t, imageCmd.Execute())
+
+		b, err := os.ReadFile(filepath.Join(buildDir, "Dockerfile"))
+		ok(t, err)
+
+		dockerfile := string(b)
+
+		if !strings.HasPrefix(dockerfile, "FROM test-image:heroku-20") {
+			t.Fatalf("expected dockerfile to start with expected base image")
+		}
+
+		if !strings.HasSuffix(dockerfile, "CMD bundle exec puma\n") {
+			t.Fatalf("expected dockerfile to end with expected CMD from CLI")
+		}
+	})
+}
+
 func testPrepare(t *testing.T) {
 	t.Parallel()
 

--- a/image.go
+++ b/image.go
@@ -54,6 +54,7 @@ type ImageCmd struct {
 	Image    string
 	Stack    string
 	Command  string
+	NoBuild  bool
 }
 
 // Execute creates a new Docker image based on a Dockerfile that will be
@@ -64,6 +65,7 @@ type ImageCmd struct {
 func (i *ImageCmd) Execute(ctx context.Context, out Outputter) error {
 	image := StackImage(i.Image, i.Stack)
 	appDir := filepath.Join(i.BuildDir, buildpack.AppDir)
+
 	dockerfile, err := Dockerfile(image, appDir, i.Command)
 	if err != nil {
 		return fmt.Errorf("failed template Dockerfile: %w", err)
@@ -74,6 +76,10 @@ func (i *ImageCmd) Execute(ctx context.Context, out Outputter) error {
 	// #nosec G306
 	if err := os.WriteFile(dockerfilePath, dockerfile, 0644); err != nil {
 		return fmt.Errorf("failed to create Dockerfile: %w", err)
+	}
+
+	if i.NoBuild {
+		return nil
 	}
 
 	dockerBuild := exec.CommandContext(ctx, "docker", "build",


### PR DESCRIPTION
Adds a new `--process` options to the `slugcmplr image` subcommand. This
allows a user to define the CMD for the built image based on the
Procfile entries of the application being built.

e.g. if an application had the following Procfile:

```
web: bundle exec puma -C config/puma.rb
cron: bin/cron
```

Supplying `--process web` would result in using
`bundle exec puma -C config/puma.rb` as the default CMD for the image.

Closes: #29

Todo:

- [ ] Some meaningful tests