### PR TITLE
Implement an opentelemetry twirp.Interceptor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,9 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.24.0
 	go.opentelemetry.io/otel v1.0.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.0.0
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.0.0
 	go.opentelemetry.io/otel/sdk v1.0.0
+	go.opentelemetry.io/otel/trace v1.0.0
 	google.golang.org/protobuf v1.27.1
 )
 
@@ -50,7 +52,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/xanzy/ssh-agent v0.3.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.0.0 // indirect
-	go.opentelemetry.io/otel/trace v1.0.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.9.0 // indirect
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect

--- a/go.sum
+++ b/go.sum
@@ -338,6 +338,8 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.0.0 h1:Vv4wbLEjheCTPV07jEav
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.0.0/go.mod h1:3VqVbIbjAycfL1C7sIu/Uh/kACIUPWHztt8ODYwR3oM=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.0.0 h1:B9VtEB1u41Ohnl8U6rMCh1jjedu8HwFh4D0QeB+1N+0=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.0.0/go.mod h1:zhEt6O5GGJ3NCAICr4hlCPoDb2GQuh4Obb4gZBgkoQQ=
+go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.0.0 h1:FqevnwHyc+preGgT6X/ksrVf9lI4KWYvFw+Bzcit4U8=
+go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.0.0/go.mod h1:5Hvi7aUPy7oiylelqg5F4qLxBrYZjxnkZY8KtEVnpb4=
 go.opentelemetry.io/otel/sdk v1.0.0 h1:BNPMYUONPNbLneMttKSjQhOTlFLOD9U22HNG1KrIN2Y=
 go.opentelemetry.io/otel/sdk v1.0.0/go.mod h1:PCrDHlSy5x1kjezSdL37PhbFUMjrsLRshJ2zCzeXwbM=
 go.opentelemetry.io/otel/trace v1.0.0 h1:TSBr8GTEtKevYMG/2d21M989r5WJYVimhTHBKVEZuh4=

--- a/proto/ping/ping.pb.go
+++ b/proto/ping/ping.pb.go
@@ -20,6 +20,82 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type BoomRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+}
+
+func (x *BoomRequest) Reset() {
+	*x = BoomRequest{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_proto_ping_ping_proto_msgTypes[0]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *BoomRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BoomRequest) ProtoMessage() {}
+
+func (x *BoomRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_ping_ping_proto_msgTypes[0]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BoomRequest.ProtoReflect.Descriptor instead.
+func (*BoomRequest) Descriptor() ([]byte, []int) {
+	return file_proto_ping_ping_proto_rawDescGZIP(), []int{0}
+}
+
+type BoomResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+}
+
+func (x *BoomResponse) Reset() {
+	*x = BoomResponse{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_proto_ping_ping_proto_msgTypes[1]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *BoomResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BoomResponse) ProtoMessage() {}
+
+func (x *BoomResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_ping_ping_proto_msgTypes[1]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BoomResponse.ProtoReflect.Descriptor instead.
+func (*BoomResponse) Descriptor() ([]byte, []int) {
+	return file_proto_ping_ping_proto_rawDescGZIP(), []int{1}
+}
+
 type EchoRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -31,7 +107,7 @@ type EchoRequest struct {
 func (x *EchoRequest) Reset() {
 	*x = EchoRequest{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_proto_ping_ping_proto_msgTypes[0]
+		mi := &file_proto_ping_ping_proto_msgTypes[2]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -44,7 +120,7 @@ func (x *EchoRequest) String() string {
 func (*EchoRequest) ProtoMessage() {}
 
 func (x *EchoRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ping_ping_proto_msgTypes[0]
+	mi := &file_proto_ping_ping_proto_msgTypes[2]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -57,7 +133,7 @@ func (x *EchoRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EchoRequest.ProtoReflect.Descriptor instead.
 func (*EchoRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ping_ping_proto_rawDescGZIP(), []int{0}
+	return file_proto_ping_ping_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *EchoRequest) GetMsg() string {
@@ -78,7 +154,7 @@ type EchoResponse struct {
 func (x *EchoResponse) Reset() {
 	*x = EchoResponse{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_proto_ping_ping_proto_msgTypes[1]
+		mi := &file_proto_ping_ping_proto_msgTypes[3]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -91,7 +167,7 @@ func (x *EchoResponse) String() string {
 func (*EchoResponse) ProtoMessage() {}
 
 func (x *EchoResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ping_ping_proto_msgTypes[1]
+	mi := &file_proto_ping_ping_proto_msgTypes[3]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -104,7 +180,7 @@ func (x *EchoResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EchoResponse.ProtoReflect.Descriptor instead.
 func (*EchoResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ping_ping_proto_rawDescGZIP(), []int{1}
+	return file_proto_ping_ping_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *EchoResponse) GetMsg() string {
@@ -118,18 +194,23 @@ var File_proto_ping_ping_proto protoreflect.FileDescriptor
 
 var file_proto_ping_ping_proto_rawDesc = []byte{
 	0x0a, 0x15, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x70, 0x69, 0x6e, 0x67, 0x2f, 0x70, 0x69, 0x6e,
-	0x67, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x04, 0x70, 0x69, 0x6e, 0x67, 0x22, 0x1f, 0x0a,
-	0x0b, 0x45, 0x63, 0x68, 0x6f, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x10, 0x0a, 0x03,
-	0x6d, 0x73, 0x67, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x03, 0x6d, 0x73, 0x67, 0x22, 0x20,
-	0x0a, 0x0c, 0x45, 0x63, 0x68, 0x6f, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x10,
-	0x0a, 0x03, 0x6d, 0x73, 0x67, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x03, 0x6d, 0x73, 0x67,
-	0x32, 0x35, 0x0a, 0x04, 0x50, 0x69, 0x6e, 0x67, 0x12, 0x2d, 0x0a, 0x04, 0x45, 0x63, 0x68, 0x6f,
-	0x12, 0x11, 0x2e, 0x70, 0x69, 0x6e, 0x67, 0x2e, 0x45, 0x63, 0x68, 0x6f, 0x52, 0x65, 0x71, 0x75,
-	0x65, 0x73, 0x74, 0x1a, 0x12, 0x2e, 0x70, 0x69, 0x6e, 0x67, 0x2e, 0x45, 0x63, 0x68, 0x6f, 0x52,
-	0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x42, 0x2c, 0x5a, 0x2a, 0x67, 0x69, 0x74, 0x68, 0x75,
-	0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x63, 0x67, 0x61, 0x31, 0x31, 0x32, 0x33, 0x2f, 0x73, 0x6c,
-	0x75, 0x67, 0x63, 0x6d, 0x70, 0x6c, 0x72, 0x2f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73,
-	0x2f, 0x70, 0x69, 0x6e, 0x67, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x67, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x04, 0x70, 0x69, 0x6e, 0x67, 0x22, 0x0d, 0x0a,
+	0x0b, 0x42, 0x6f, 0x6f, 0x6d, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x22, 0x0e, 0x0a, 0x0c,
+	0x42, 0x6f, 0x6f, 0x6d, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x1f, 0x0a, 0x0b,
+	0x45, 0x63, 0x68, 0x6f, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x10, 0x0a, 0x03, 0x6d,
+	0x73, 0x67, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x03, 0x6d, 0x73, 0x67, 0x22, 0x20, 0x0a,
+	0x0c, 0x45, 0x63, 0x68, 0x6f, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x10, 0x0a,
+	0x03, 0x6d, 0x73, 0x67, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x03, 0x6d, 0x73, 0x67, 0x32,
+	0x64, 0x0a, 0x04, 0x50, 0x69, 0x6e, 0x67, 0x12, 0x2d, 0x0a, 0x04, 0x45, 0x63, 0x68, 0x6f, 0x12,
+	0x11, 0x2e, 0x70, 0x69, 0x6e, 0x67, 0x2e, 0x45, 0x63, 0x68, 0x6f, 0x52, 0x65, 0x71, 0x75, 0x65,
+	0x73, 0x74, 0x1a, 0x12, 0x2e, 0x70, 0x69, 0x6e, 0x67, 0x2e, 0x45, 0x63, 0x68, 0x6f, 0x52, 0x65,
+	0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x2d, 0x0a, 0x04, 0x42, 0x6f, 0x6f, 0x6d, 0x12, 0x11,
+	0x2e, 0x70, 0x69, 0x6e, 0x67, 0x2e, 0x42, 0x6f, 0x6f, 0x6d, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73,
+	0x74, 0x1a, 0x12, 0x2e, 0x70, 0x69, 0x6e, 0x67, 0x2e, 0x42, 0x6f, 0x6f, 0x6d, 0x52, 0x65, 0x73,
+	0x70, 0x6f, 0x6e, 0x73, 0x65, 0x42, 0x2c, 0x5a, 0x2a, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e,
+	0x63, 0x6f, 0x6d, 0x2f, 0x63, 0x67, 0x61, 0x31, 0x31, 0x32, 0x33, 0x2f, 0x73, 0x6c, 0x75, 0x67,
+	0x63, 0x6d, 0x70, 0x6c, 0x72, 0x2f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x2f, 0x70,
+	0x69, 0x6e, 0x67, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -144,16 +225,20 @@ func file_proto_ping_ping_proto_rawDescGZIP() []byte {
 	return file_proto_ping_ping_proto_rawDescData
 }
 
-var file_proto_ping_ping_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_proto_ping_ping_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_proto_ping_ping_proto_goTypes = []interface{}{
-	(*EchoRequest)(nil),  // 0: ping.EchoRequest
-	(*EchoResponse)(nil), // 1: ping.EchoResponse
+	(*BoomRequest)(nil),  // 0: ping.BoomRequest
+	(*BoomResponse)(nil), // 1: ping.BoomResponse
+	(*EchoRequest)(nil),  // 2: ping.EchoRequest
+	(*EchoResponse)(nil), // 3: ping.EchoResponse
 }
 var file_proto_ping_ping_proto_depIdxs = []int32{
-	0, // 0: ping.Ping.Echo:input_type -> ping.EchoRequest
-	1, // 1: ping.Ping.Echo:output_type -> ping.EchoResponse
-	1, // [1:2] is the sub-list for method output_type
-	0, // [0:1] is the sub-list for method input_type
+	2, // 0: ping.Ping.Echo:input_type -> ping.EchoRequest
+	0, // 1: ping.Ping.Boom:input_type -> ping.BoomRequest
+	3, // 2: ping.Ping.Echo:output_type -> ping.EchoResponse
+	1, // 3: ping.Ping.Boom:output_type -> ping.BoomResponse
+	2, // [2:4] is the sub-list for method output_type
+	0, // [0:2] is the sub-list for method input_type
 	0, // [0:0] is the sub-list for extension type_name
 	0, // [0:0] is the sub-list for extension extendee
 	0, // [0:0] is the sub-list for field type_name
@@ -166,7 +251,7 @@ func file_proto_ping_ping_proto_init() {
 	}
 	if !protoimpl.UnsafeEnabled {
 		file_proto_ping_ping_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*EchoRequest); i {
+			switch v := v.(*BoomRequest); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -178,6 +263,30 @@ func file_proto_ping_ping_proto_init() {
 			}
 		}
 		file_proto_ping_ping_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*BoomResponse); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_proto_ping_ping_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*EchoRequest); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_proto_ping_ping_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*EchoResponse); i {
 			case 0:
 				return &v.state
@@ -196,7 +305,7 @@ func file_proto_ping_ping_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_proto_ping_ping_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   2,
+			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/ping/ping.proto
+++ b/proto/ping/ping.proto
@@ -6,7 +6,11 @@ option go_package = "github.com/cga1123/slugcmplr/services/ping";
 
 service Ping {
   rpc Echo(EchoRequest) returns (EchoResponse);
+  rpc Boom(BoomRequest) returns (BoomResponse);
 }
+
+message BoomRequest {}
+message BoomResponse {}
 
 message EchoRequest {
   string msg = 1;

--- a/proto/ping/ping.twirp.go
+++ b/proto/ping/ping.twirp.go
@@ -34,6 +34,8 @@ const _ = twirp.TwirpPackageMinVersion_8_1_0
 
 type Ping interface {
 	Echo(context.Context, *EchoRequest) (*EchoResponse, error)
+
+	Boom(context.Context, *BoomRequest) (*BoomResponse, error)
 }
 
 // ====================
@@ -42,7 +44,7 @@ type Ping interface {
 
 type pingProtobufClient struct {
 	client      HTTPClient
-	urls        [1]string
+	urls        [2]string
 	interceptor twirp.Interceptor
 	opts        twirp.ClientOptions
 }
@@ -70,8 +72,9 @@ func NewPingProtobufClient(baseURL string, client HTTPClient, opts ...twirp.Clie
 	// Build method URLs: <baseURL>[<prefix>]/<package>.<Service>/<Method>
 	serviceURL := sanitizeBaseURL(baseURL)
 	serviceURL += baseServicePath(pathPrefix, "ping", "Ping")
-	urls := [1]string{
+	urls := [2]string{
 		serviceURL + "Echo",
+		serviceURL + "Boom",
 	}
 
 	return &pingProtobufClient{
@@ -128,13 +131,59 @@ func (c *pingProtobufClient) callEcho(ctx context.Context, in *EchoRequest) (*Ec
 	return out, nil
 }
 
+func (c *pingProtobufClient) Boom(ctx context.Context, in *BoomRequest) (*BoomResponse, error) {
+	ctx = ctxsetters.WithPackageName(ctx, "ping")
+	ctx = ctxsetters.WithServiceName(ctx, "Ping")
+	ctx = ctxsetters.WithMethodName(ctx, "Boom")
+	caller := c.callBoom
+	if c.interceptor != nil {
+		caller = func(ctx context.Context, req *BoomRequest) (*BoomResponse, error) {
+			resp, err := c.interceptor(
+				func(ctx context.Context, req interface{}) (interface{}, error) {
+					typedReq, ok := req.(*BoomRequest)
+					if !ok {
+						return nil, twirp.InternalError("failed type assertion req.(*BoomRequest) when calling interceptor")
+					}
+					return c.callBoom(ctx, typedReq)
+				},
+			)(ctx, req)
+			if resp != nil {
+				typedResp, ok := resp.(*BoomResponse)
+				if !ok {
+					return nil, twirp.InternalError("failed type assertion resp.(*BoomResponse) when calling interceptor")
+				}
+				return typedResp, err
+			}
+			return nil, err
+		}
+	}
+	return caller(ctx, in)
+}
+
+func (c *pingProtobufClient) callBoom(ctx context.Context, in *BoomRequest) (*BoomResponse, error) {
+	out := new(BoomResponse)
+	ctx, err := doProtobufRequest(ctx, c.client, c.opts.Hooks, c.urls[1], in, out)
+	if err != nil {
+		twerr, ok := err.(twirp.Error)
+		if !ok {
+			twerr = twirp.InternalErrorWith(err)
+		}
+		callClientError(ctx, c.opts.Hooks, twerr)
+		return nil, err
+	}
+
+	callClientResponseReceived(ctx, c.opts.Hooks)
+
+	return out, nil
+}
+
 // ================
 // Ping JSON Client
 // ================
 
 type pingJSONClient struct {
 	client      HTTPClient
-	urls        [1]string
+	urls        [2]string
 	interceptor twirp.Interceptor
 	opts        twirp.ClientOptions
 }
@@ -162,8 +211,9 @@ func NewPingJSONClient(baseURL string, client HTTPClient, opts ...twirp.ClientOp
 	// Build method URLs: <baseURL>[<prefix>]/<package>.<Service>/<Method>
 	serviceURL := sanitizeBaseURL(baseURL)
 	serviceURL += baseServicePath(pathPrefix, "ping", "Ping")
-	urls := [1]string{
+	urls := [2]string{
 		serviceURL + "Echo",
+		serviceURL + "Boom",
 	}
 
 	return &pingJSONClient{
@@ -206,6 +256,52 @@ func (c *pingJSONClient) Echo(ctx context.Context, in *EchoRequest) (*EchoRespon
 func (c *pingJSONClient) callEcho(ctx context.Context, in *EchoRequest) (*EchoResponse, error) {
 	out := new(EchoResponse)
 	ctx, err := doJSONRequest(ctx, c.client, c.opts.Hooks, c.urls[0], in, out)
+	if err != nil {
+		twerr, ok := err.(twirp.Error)
+		if !ok {
+			twerr = twirp.InternalErrorWith(err)
+		}
+		callClientError(ctx, c.opts.Hooks, twerr)
+		return nil, err
+	}
+
+	callClientResponseReceived(ctx, c.opts.Hooks)
+
+	return out, nil
+}
+
+func (c *pingJSONClient) Boom(ctx context.Context, in *BoomRequest) (*BoomResponse, error) {
+	ctx = ctxsetters.WithPackageName(ctx, "ping")
+	ctx = ctxsetters.WithServiceName(ctx, "Ping")
+	ctx = ctxsetters.WithMethodName(ctx, "Boom")
+	caller := c.callBoom
+	if c.interceptor != nil {
+		caller = func(ctx context.Context, req *BoomRequest) (*BoomResponse, error) {
+			resp, err := c.interceptor(
+				func(ctx context.Context, req interface{}) (interface{}, error) {
+					typedReq, ok := req.(*BoomRequest)
+					if !ok {
+						return nil, twirp.InternalError("failed type assertion req.(*BoomRequest) when calling interceptor")
+					}
+					return c.callBoom(ctx, typedReq)
+				},
+			)(ctx, req)
+			if resp != nil {
+				typedResp, ok := resp.(*BoomResponse)
+				if !ok {
+					return nil, twirp.InternalError("failed type assertion resp.(*BoomResponse) when calling interceptor")
+				}
+				return typedResp, err
+			}
+			return nil, err
+		}
+	}
+	return caller(ctx, in)
+}
+
+func (c *pingJSONClient) callBoom(ctx context.Context, in *BoomRequest) (*BoomResponse, error) {
+	out := new(BoomResponse)
+	ctx, err := doJSONRequest(ctx, c.client, c.opts.Hooks, c.urls[1], in, out)
 	if err != nil {
 		twerr, ok := err.(twirp.Error)
 		if !ok {
@@ -319,6 +415,9 @@ func (s *pingServer) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	switch method {
 	case "Echo":
 		s.serveEcho(ctx, resp, req)
+		return
+	case "Boom":
+		s.serveBoom(ctx, resp, req)
 		return
 	default:
 		msg := fmt.Sprintf("no handler for path %q", req.URL.Path)
@@ -484,6 +583,186 @@ func (s *pingServer) serveEchoProtobuf(ctx context.Context, resp http.ResponseWr
 	}
 	if respContent == nil {
 		s.writeError(ctx, resp, twirp.InternalError("received a nil *EchoResponse and nil error while calling Echo. nil responses are not supported"))
+		return
+	}
+
+	ctx = callResponsePrepared(ctx, s.hooks)
+
+	respBytes, err := proto.Marshal(respContent)
+	if err != nil {
+		s.writeError(ctx, resp, wrapInternal(err, "failed to marshal proto response"))
+		return
+	}
+
+	ctx = ctxsetters.WithStatusCode(ctx, http.StatusOK)
+	resp.Header().Set("Content-Type", "application/protobuf")
+	resp.Header().Set("Content-Length", strconv.Itoa(len(respBytes)))
+	resp.WriteHeader(http.StatusOK)
+	if n, err := resp.Write(respBytes); err != nil {
+		msg := fmt.Sprintf("failed to write response, %d of %d bytes written: %s", n, len(respBytes), err.Error())
+		twerr := twirp.NewError(twirp.Unknown, msg)
+		ctx = callError(ctx, s.hooks, twerr)
+	}
+	callResponseSent(ctx, s.hooks)
+}
+
+func (s *pingServer) serveBoom(ctx context.Context, resp http.ResponseWriter, req *http.Request) {
+	header := req.Header.Get("Content-Type")
+	i := strings.Index(header, ";")
+	if i == -1 {
+		i = len(header)
+	}
+	switch strings.TrimSpace(strings.ToLower(header[:i])) {
+	case "application/json":
+		s.serveBoomJSON(ctx, resp, req)
+	case "application/protobuf":
+		s.serveBoomProtobuf(ctx, resp, req)
+	default:
+		msg := fmt.Sprintf("unexpected Content-Type: %q", req.Header.Get("Content-Type"))
+		twerr := badRouteError(msg, req.Method, req.URL.Path)
+		s.writeError(ctx, resp, twerr)
+	}
+}
+
+func (s *pingServer) serveBoomJSON(ctx context.Context, resp http.ResponseWriter, req *http.Request) {
+	var err error
+	ctx = ctxsetters.WithMethodName(ctx, "Boom")
+	ctx, err = callRequestRouted(ctx, s.hooks)
+	if err != nil {
+		s.writeError(ctx, resp, err)
+		return
+	}
+
+	d := json.NewDecoder(req.Body)
+	rawReqBody := json.RawMessage{}
+	if err := d.Decode(&rawReqBody); err != nil {
+		s.handleRequestBodyError(ctx, resp, "the json request could not be decoded", err)
+		return
+	}
+	reqContent := new(BoomRequest)
+	unmarshaler := protojson.UnmarshalOptions{DiscardUnknown: true}
+	if err = unmarshaler.Unmarshal(rawReqBody, reqContent); err != nil {
+		s.handleRequestBodyError(ctx, resp, "the json request could not be decoded", err)
+		return
+	}
+
+	handler := s.Ping.Boom
+	if s.interceptor != nil {
+		handler = func(ctx context.Context, req *BoomRequest) (*BoomResponse, error) {
+			resp, err := s.interceptor(
+				func(ctx context.Context, req interface{}) (interface{}, error) {
+					typedReq, ok := req.(*BoomRequest)
+					if !ok {
+						return nil, twirp.InternalError("failed type assertion req.(*BoomRequest) when calling interceptor")
+					}
+					return s.Ping.Boom(ctx, typedReq)
+				},
+			)(ctx, req)
+			if resp != nil {
+				typedResp, ok := resp.(*BoomResponse)
+				if !ok {
+					return nil, twirp.InternalError("failed type assertion resp.(*BoomResponse) when calling interceptor")
+				}
+				return typedResp, err
+			}
+			return nil, err
+		}
+	}
+
+	// Call service method
+	var respContent *BoomResponse
+	func() {
+		defer ensurePanicResponses(ctx, resp, s.hooks)
+		respContent, err = handler(ctx, reqContent)
+	}()
+
+	if err != nil {
+		s.writeError(ctx, resp, err)
+		return
+	}
+	if respContent == nil {
+		s.writeError(ctx, resp, twirp.InternalError("received a nil *BoomResponse and nil error while calling Boom. nil responses are not supported"))
+		return
+	}
+
+	ctx = callResponsePrepared(ctx, s.hooks)
+
+	marshaler := &protojson.MarshalOptions{UseProtoNames: !s.jsonCamelCase, EmitUnpopulated: !s.jsonSkipDefaults}
+	respBytes, err := marshaler.Marshal(respContent)
+	if err != nil {
+		s.writeError(ctx, resp, wrapInternal(err, "failed to marshal json response"))
+		return
+	}
+
+	ctx = ctxsetters.WithStatusCode(ctx, http.StatusOK)
+	resp.Header().Set("Content-Type", "application/json")
+	resp.Header().Set("Content-Length", strconv.Itoa(len(respBytes)))
+	resp.WriteHeader(http.StatusOK)
+
+	if n, err := resp.Write(respBytes); err != nil {
+		msg := fmt.Sprintf("failed to write response, %d of %d bytes written: %s", n, len(respBytes), err.Error())
+		twerr := twirp.NewError(twirp.Unknown, msg)
+		ctx = callError(ctx, s.hooks, twerr)
+	}
+	callResponseSent(ctx, s.hooks)
+}
+
+func (s *pingServer) serveBoomProtobuf(ctx context.Context, resp http.ResponseWriter, req *http.Request) {
+	var err error
+	ctx = ctxsetters.WithMethodName(ctx, "Boom")
+	ctx, err = callRequestRouted(ctx, s.hooks)
+	if err != nil {
+		s.writeError(ctx, resp, err)
+		return
+	}
+
+	buf, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		s.handleRequestBodyError(ctx, resp, "failed to read request body", err)
+		return
+	}
+	reqContent := new(BoomRequest)
+	if err = proto.Unmarshal(buf, reqContent); err != nil {
+		s.writeError(ctx, resp, malformedRequestError("the protobuf request could not be decoded"))
+		return
+	}
+
+	handler := s.Ping.Boom
+	if s.interceptor != nil {
+		handler = func(ctx context.Context, req *BoomRequest) (*BoomResponse, error) {
+			resp, err := s.interceptor(
+				func(ctx context.Context, req interface{}) (interface{}, error) {
+					typedReq, ok := req.(*BoomRequest)
+					if !ok {
+						return nil, twirp.InternalError("failed type assertion req.(*BoomRequest) when calling interceptor")
+					}
+					return s.Ping.Boom(ctx, typedReq)
+				},
+			)(ctx, req)
+			if resp != nil {
+				typedResp, ok := resp.(*BoomResponse)
+				if !ok {
+					return nil, twirp.InternalError("failed type assertion resp.(*BoomResponse) when calling interceptor")
+				}
+				return typedResp, err
+			}
+			return nil, err
+		}
+	}
+
+	// Call service method
+	var respContent *BoomResponse
+	func() {
+		defer ensurePanicResponses(ctx, resp, s.hooks)
+		respContent, err = handler(ctx, reqContent)
+	}()
+
+	if err != nil {
+		s.writeError(ctx, resp, err)
+		return
+	}
+	if respContent == nil {
+		s.writeError(ctx, resp, twirp.InternalError("received a nil *BoomResponse and nil error while calling Boom. nil responses are not supported"))
 		return
 	}
 
@@ -1091,16 +1370,18 @@ func callClientError(ctx context.Context, h *twirp.ClientHooks, err twirp.Error)
 }
 
 var twirpFileDescriptor0 = []byte{
-	// 165 bytes of a gzipped FileDescriptorProto
+	// 197 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0x2d, 0x28, 0xca, 0x2f,
-	0xc9, 0xd7, 0x2f, 0xc8, 0xcc, 0x4b, 0x07, 0x13, 0x7a, 0x60, 0xbe, 0x10, 0x0b, 0x88, 0xad, 0x24,
-	0xcf, 0xc5, 0xed, 0x9a, 0x9c, 0x91, 0x1f, 0x94, 0x5a, 0x58, 0x9a, 0x5a, 0x5c, 0x22, 0x24, 0xc0,
-	0xc5, 0x9c, 0x5b, 0x9c, 0x2e, 0xc1, 0xa8, 0xc0, 0xa8, 0xc1, 0x19, 0x04, 0x62, 0x2a, 0x29, 0x70,
-	0xf1, 0x40, 0x14, 0x14, 0x17, 0xe4, 0xe7, 0x15, 0xa7, 0x62, 0xaa, 0x30, 0x32, 0xe5, 0x62, 0x09,
-	0xc8, 0xcc, 0x4b, 0x17, 0xd2, 0xe5, 0x62, 0x01, 0xa9, 0x14, 0x12, 0xd4, 0x03, 0xdb, 0x82, 0x64,
-	0xac, 0x94, 0x10, 0xb2, 0x10, 0xc4, 0x20, 0x27, 0x9d, 0x28, 0xad, 0xf4, 0xcc, 0x92, 0x8c, 0xd2,
-	0x24, 0xbd, 0xe4, 0xfc, 0x5c, 0xfd, 0xe4, 0xf4, 0x44, 0x43, 0x43, 0x23, 0x63, 0xfd, 0xe2, 0x9c,
-	0xd2, 0xf4, 0xe4, 0xdc, 0x82, 0x9c, 0x22, 0xfd, 0xe2, 0xd4, 0xa2, 0xb2, 0xcc, 0xe4, 0xd4, 0x62,
-	0xb0, 0x9b, 0x93, 0xd8, 0xc0, 0x8e, 0x36, 0x06, 0x04, 0x00, 0x00, 0xff, 0xff, 0xfe, 0x7a, 0x1e,
-	0x92, 0xcd, 0x00, 0x00, 0x00,
+	0xc9, 0xd7, 0x2f, 0xc8, 0xcc, 0x4b, 0x07, 0x13, 0x7a, 0x60, 0xbe, 0x10, 0x0b, 0x88, 0xad, 0xc4,
+	0xcb, 0xc5, 0xed, 0x94, 0x9f, 0x9f, 0x1b, 0x94, 0x5a, 0x58, 0x9a, 0x5a, 0x5c, 0xa2, 0xc4, 0xc7,
+	0xc5, 0x03, 0xe1, 0x16, 0x17, 0xe4, 0xe7, 0x15, 0xa7, 0x2a, 0xc9, 0x73, 0x71, 0xbb, 0x26, 0x67,
+	0xe4, 0x43, 0xa5, 0x85, 0x04, 0xb8, 0x98, 0x73, 0x8b, 0xd3, 0x25, 0x18, 0x15, 0x18, 0x35, 0x38,
+	0x83, 0x40, 0x4c, 0x25, 0x05, 0x2e, 0x1e, 0x88, 0x02, 0x88, 0x06, 0x4c, 0x15, 0x46, 0x29, 0x5c,
+	0x2c, 0x01, 0x99, 0x79, 0xe9, 0x42, 0xba, 0x5c, 0x2c, 0x20, 0x95, 0x42, 0x82, 0x7a, 0x60, 0x47,
+	0x20, 0x19, 0x2b, 0x25, 0x84, 0x2c, 0x04, 0x35, 0x48, 0x97, 0x8b, 0x05, 0xe4, 0x12, 0x98, 0x72,
+	0x24, 0x47, 0xc2, 0x94, 0x23, 0x3b, 0xd4, 0x49, 0x27, 0x4a, 0x2b, 0x3d, 0xb3, 0x24, 0xa3, 0x34,
+	0x49, 0x2f, 0x39, 0x3f, 0x57, 0x3f, 0x39, 0x3d, 0xd1, 0xd0, 0xd0, 0xc8, 0x58, 0xbf, 0x38, 0xa7,
+	0x34, 0x3d, 0x39, 0xb7, 0x20, 0xa7, 0x48, 0xbf, 0x38, 0xb5, 0xa8, 0x2c, 0x33, 0x39, 0xb5, 0x18,
+	0x1c, 0x02, 0x49, 0x6c, 0xe0, 0x20, 0x30, 0x06, 0x04, 0x00, 0x00, 0xff, 0xff, 0x7e, 0x58, 0xc9,
+	0xb9, 0x1b, 0x01, 0x00, 0x00,
 }

--- a/services/pingsvc/ping.go
+++ b/services/pingsvc/ping.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	proto "github.com/cga1123/slugcmplr/proto/ping"
+	"github.com/twitchtv/twirp"
 )
 
 var _ proto.Ping = (*Service)(nil)
@@ -14,4 +15,9 @@ type Service struct{}
 // Echo echoes its given message.
 func (s *Service) Echo(_ context.Context, r *proto.EchoRequest) (*proto.EchoResponse, error) {
 	return &proto.EchoResponse{Msg: r.Msg}, nil
+}
+
+// Boom returns an error.
+func (s *Service) Boom(_ context.Context, _ *proto.BoomRequest) (*proto.BoomResponse, error) {
+	return nil, twirp.InternalError("boom")
 }


### PR DESCRIPTION
Sets up a `twirp.Interceptor` which wraps a twirp RPC call and adds
semconv rpc attributes to the current span.

- `rpc.system` will be `"twirp"`
- `rpc.service` will be the twirp service name (as defined in the `rpc`
  proto block).
- `rpc.method` will be the twirp method name (as defined in the `rpc`
  proto block).
- `rpc.error_code` will be the twirp.ErrorCode string, if an error
  occured.
- `rpc.error_message` will be the twirp error message, if an error
  occured.

When a non `twirp.Error` is returned the `rpc.error_code` will be
`"other"`.

This implementation also adds the following non semantically
conventional attributes:
- `rpc.package` the twirp package (as defined in the proto definition)
- `rpc.fqn` the fully qualified twirp method name
  (package.service/method)