### PR TITLE
Parallelise commands and add opentelemetry

### DIFF
--- a/cmd/slugcmplr/compile.go
+++ b/cmd/slugcmplr/compile.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cga1123/slugcmplr/buildpack"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel"
 )
 
 const defaultImage = "ghcr.io/cga1123/slugcmplr:" + slugcmplr.StackReplacePattern
@@ -35,6 +36,7 @@ func compile(ctx context.Context, out outputter, h *heroku.Service, c *Compile, 
 		Stack:         c.Stack,
 		SourceVersion: c.SourceVersion,
 		Buildpacks:    c.Buildpacks,
+		Tracer:        otel.Tracer("github.com/CGA1123/slugcmplr/cmd"),
 	}
 
 	result, err := compileCmd.Execute(ctx, out)

--- a/cmd/slugcmplr/prepare.go
+++ b/cmd/slugcmplr/prepare.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cga1123/slugcmplr"
 	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel"
 )
 
 func writeMetadata(m *slugcmplr.MetadataResult, pr *slugcmplr.PrepareResult) error {
@@ -74,6 +75,7 @@ func prepareCmd(verbose bool) *cobra.Command {
 				Application: application,
 				SourceDir:   srcDir,
 				BuildDir:    buildDir,
+				Tracer:      otel.Tracer("github.com/CGA1123/slugcmplr/cmd"),
 			}).Execute(ctx, output)
 			if err != nil {
 				return fmt.Errorf("error fetching app metadata: %w", err)
@@ -89,6 +91,7 @@ func prepareCmd(verbose bool) *cobra.Command {
 				BuildDir:   buildDir,
 				ConfigVars: m.ConfigVars,
 				Buildpacks: m.Buildpacks,
+				Tracer:     otel.Tracer("github.com/CGA1123/slugcmplr/cmd"),
 			}).Execute(ctx, output)
 			if err != nil {
 				return fmt.Errorf("error preparing application: %w", err)

--- a/cmd/slugcmplr/test_helper.go
+++ b/cmd/slugcmplr/test_helper.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cga1123/slugcmplr"
 	git "github.com/go-git/go-git/v5"
 	heroku "github.com/heroku/heroku-go/v5"
+	"go.opentelemetry.io/otel"
 )
 
 func sliceEqual(a, b interface{}, eq func(i int) bool) bool {
@@ -246,6 +247,7 @@ func withStubPrepare(t *testing.T, fixture string, buildpacks []*slugcmplr.Build
 		BuildDir:   builddir,
 		ConfigVars: m.ConfigVars,
 		Buildpacks: m.Buildpacks,
+		Tracer:     otel.Tracer("github.com/slugcmlr/test"),
 	}
 
 	pr, err := p.Execute(context.Background(), &stdOutputter{})

--- a/metadata.go
+++ b/metadata.go
@@ -6,6 +6,9 @@ import (
 	"sort"
 
 	heroku "github.com/heroku/heroku-go/v5"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/errgroup"
 )
 
 // MetadataCmd wraps up all the information required to fetch metadata require
@@ -15,6 +18,7 @@ type MetadataCmd struct {
 	Application string
 	SourceDir   string
 	BuildDir    string
+	Tracer      trace.Tracer
 }
 
 // MetadataResult contains the result of resolving metadata for an application.
@@ -30,31 +34,69 @@ type MetadataResult struct {
 // variables. It will also resolve the current HEAD commit of the source to be
 // compiled.
 func (m *MetadataCmd) Execute(ctx context.Context, _ Outputter) (*MetadataResult, error) {
+	sctx, span := m.Tracer.Start(ctx, "slugcmplr_metadata",
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(
+			attribute.String("type", "command"),
+			attribute.String("command.name", "metadata"),
+		),
+	)
+	defer span.End()
+
+	g, gctx := errgroup.WithContext(sctx)
+
+	var commit string
+	var app *heroku.App
+	var config heroku.ConfigVarInfoForAppResult
+	var buildpacks heroku.BuildpackInstallationListResult
+
 	commit, err := Commit(m.SourceDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve commit: %w", err)
 	}
 
-	app, err := m.Heroku.AppInfo(ctx, m.Application)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch app info: %w", err)
-	}
+	g.Go(func() error {
+		a, err := m.Heroku.AppInfo(gctx, m.Application)
+		if err != nil {
+			return fmt.Errorf("failed to fetch app info: %w", err)
+		}
 
-	conf, err := m.Heroku.ConfigVarInfoForApp(ctx, m.Application)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch app configuration: %w", err)
-	}
+		app = a
 
-	bpi, err := m.Heroku.BuildpackInstallationList(ctx, m.Application, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch app buildpacks: %w", err)
+		return nil
+	})
+
+	g.Go(func() error {
+		c, err := m.Heroku.ConfigVarInfoForApp(gctx, m.Application)
+		if err != nil {
+			return fmt.Errorf("failed to fetch app configuration: %w", err)
+		}
+
+		config = c
+
+		return nil
+	})
+
+	g.Go(func() error {
+		bpi, err := m.Heroku.BuildpackInstallationList(gctx, m.Application, nil)
+		if err != nil {
+			return fmt.Errorf("failed to fetch app buildpacks: %w", err)
+		}
+
+		buildpacks = bpi
+
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, err
 	}
 
 	return &MetadataResult{
 		ApplicationName: app.Name,
 		Stack:           app.Stack.Name,
-		Buildpacks:      buildBuildpacks(bpi),
-		ConfigVars:      buildConfigVars(conf),
+		Buildpacks:      buildBuildpacks(buildpacks),
+		ConfigVars:      buildConfigVars(config),
 		SourceVersion:   commit,
 	}, nil
 }

--- a/prepare.go
+++ b/prepare.go
@@ -10,6 +10,9 @@ import (
 	"github.com/cga1123/slugcmplr/buildpack"
 	"github.com/cga1123/slugcmplr/slugignore"
 	"github.com/otiai10/copy"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/errgroup"
 )
 
 // PrepareCmd wraps up all the information required to prepare an application
@@ -19,6 +22,7 @@ type PrepareCmd struct {
 	BuildDir   string
 	ConfigVars map[string]string
 	Buildpacks []*BuildpackReference
+	Tracer     trace.Tracer
 }
 
 // PrepareResult contains the result of preparing, including the path to the
@@ -33,43 +37,54 @@ type PrepareResult struct {
 // buildpack, copying the source into the build directory, and writing out the
 // application environment.
 func (p *PrepareCmd) Execute(ctx context.Context, _ Outputter) (*PrepareResult, error) {
-	envDir := filepath.Join(p.BuildDir, buildpack.EnvironmentDir)
-	buildpacksDir := filepath.Join(p.BuildDir, buildpack.BuildpacksDir)
+	sctx, span := p.Tracer.Start(ctx, "slugcmplr_prepare",
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(
+			attribute.String("type", "command"),
+			attribute.String("command.name", "prepare"),
+		),
+	)
+	defer span.End()
+
+	g, gctx := errgroup.WithContext(sctx)
+
+	var bps []*buildpack.Buildpack
+	g.Go(func() error {
+		return p.writeEnvDir(gctx)
+	})
+
+	g.Go(func() error {
+		return p.copySource(gctx)
+	})
+
+	g.Go(func() error {
+		var err error
+
+		bps, err = p.downloadBuildpacks(gctx)
+
+		return err
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	return &PrepareResult{
+		BuildDir:   p.BuildDir,
+		Buildpacks: bps,
+	}, nil
+}
+
+func (p *PrepareCmd) copySource(ctx context.Context) error {
+	_, span := p.Tracer.Start(ctx, "copy_source",
+		trace.WithSpanKind(trace.SpanKindInternal),
+	)
+	defer span.End()
+
 	appDir := filepath.Join(p.BuildDir, buildpack.AppDir)
-
-	// Download Buildpacks
-	// TODO: Do this in parallel?
-	bps := make([]*buildpack.Buildpack, len(p.Buildpacks))
-	for i, bp := range p.Buildpacks {
-		src, err := buildpack.ParseSource(bp.URL)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse buildpack source: %w", err)
-		}
-
-		bp, err := src.Download(ctx, buildpacksDir)
-		if err != nil {
-			return nil, fmt.Errorf("failed to download buildpack: %w", err)
-		}
-
-		bps[i] = bp
-	}
-
-	// Write config vars to the envDir.
-	if err := os.MkdirAll(envDir, 0700); err != nil {
-		return nil, fmt.Errorf("failed to mkdir (%v): %w", envDir, err)
-	}
-
-	for name, value := range p.ConfigVars {
-		if err := os.WriteFile(filepath.Join(envDir, name), []byte(value), 0600); err != nil {
-			return nil, fmt.Errorf("error writing %v: %w", name, err)
-		}
-	}
-
-	// Copy source to the SourceDir, respecting any .slugignore file, if it
-	// exists.
 	ignore, err := slugignore.ForDirectory(p.SourceDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read .slugignore: %w", err)
+		return fmt.Errorf("failed to read .slugignore: %w", err)
 	}
 
 	if err := copy.Copy(p.SourceDir, appDir, copy.Options{
@@ -79,11 +94,82 @@ func (p *PrepareCmd) Execute(ctx context.Context, _ Outputter) (*PrepareResult, 
 			), nil
 		},
 	}); err != nil {
-		return nil, fmt.Errorf("failed to copy source: %w", err)
+		return fmt.Errorf("failed to copy source: %w", err)
 	}
 
-	return &PrepareResult{
-		BuildDir:   p.BuildDir,
-		Buildpacks: bps,
-	}, nil
+	return nil
+}
+
+func (p *PrepareCmd) writeEnvDir(ctx context.Context) error {
+	_, span := p.Tracer.Start(ctx, "write_env_dir",
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(
+			attribute.Int("env.count", len(p.ConfigVars)),
+		),
+	)
+	defer span.End()
+
+	envDir := filepath.Join(p.BuildDir, buildpack.EnvironmentDir)
+	if err := os.MkdirAll(envDir, 0700); err != nil {
+		return fmt.Errorf("failed to mkdir (%v): %w", envDir, err)
+	}
+
+	for name, value := range p.ConfigVars {
+		if err := os.WriteFile(filepath.Join(envDir, name), []byte(value), 0600); err != nil {
+			return fmt.Errorf("error writing %v: %w", name, err)
+		}
+	}
+
+	return nil
+}
+
+func (p *PrepareCmd) downloadBuildpacks(ctx context.Context) ([]*buildpack.Buildpack, error) {
+	sctx, span := p.Tracer.Start(ctx, "download_buildpacks",
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(
+			attribute.Int("buildpacks.count", len(p.Buildpacks)),
+		),
+	)
+	defer span.End()
+
+	buildpacksDir := filepath.Join(p.BuildDir, buildpack.BuildpacksDir)
+
+	bps := make([]*buildpack.Buildpack, len(p.Buildpacks))
+	download := func(ctx context.Context, urn string, idx int) func() error {
+		return func() error {
+			sctx, span := p.Tracer.Start(ctx, "download_buildpack",
+				trace.WithSpanKind(trace.SpanKindInternal),
+				trace.WithAttributes(
+					attribute.String("buildpack.urn", urn),
+					attribute.Int("buildpack.idx", idx),
+				),
+			)
+			defer span.End()
+
+			src, err := buildpack.ParseSource(urn)
+			if err != nil {
+				return fmt.Errorf("failed to parse buildpack source: %w", err)
+			}
+
+			bp, err := src.Download(sctx, buildpacksDir)
+			if err != nil {
+				return fmt.Errorf("failed to download buildpack: %w", err)
+			}
+
+			bps[idx] = bp
+
+			return nil
+		}
+	}
+
+	g, gctx := errgroup.WithContext(sctx)
+	for i, bp := range p.Buildpacks {
+		g.Go(download(gctx, bp.URL, i))
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	return bps, nil
 }


### PR DESCRIPTION
Parallelise prepare and metadata steps where possible and add spans for
prepare, metadata, and compile commands.