### PR TITLE
Retry buildpack.Download on error

### DIFF
--- a/buildpack/buildpack_source.go
+++ b/buildpack/buildpack_source.go
@@ -89,7 +89,7 @@ func (s *TargzSource) Download(ctx context.Context, baseDir string) (*Buildpack,
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file: %w", err)
 	}
-	defer f.Close()
+	defer f.Close() // nolint:errcheck
 
 	if err := Untargz(
 		f,
@@ -109,7 +109,7 @@ func download(ctx context.Context, url string) (string, error) {
 		if err != nil {
 			return fmt.Errorf("failed creating tmpfile: %w", err)
 		}
-		defer f.Close()
+		defer f.Close() // nolint:errcheck
 
 		path = f.Name()
 


### PR DESCRIPTION
Add exponential backoff retries when attempting to download buildpacks
in order to mitigate against flaky networks.

Related: #71 