### PR TITLE
Use BuildStack to determine the stack name

### DIFF
--- a/metadata.go
+++ b/metadata.go
@@ -52,7 +52,7 @@ func (m *MetadataCmd) Execute(ctx context.Context, _ Outputter) (*MetadataResult
 
 	return &MetadataResult{
 		ApplicationName: app.Name,
-		Stack:           app.Stack.Name,
+		Stack:           app.BuildStack.Name,
 		Buildpacks:      buildBuildpacks(bpi),
 		ConfigVars:      buildConfigVars(conf),
 		SourceVersion:   commit,


### PR DESCRIPTION
Hi Christian 👋 

Just a little change to use the correct build target Heroku stack.

The heroku lib's "Stack" field shows the **current** application stack name.
If you want to migrate your app's stacks, you set a new build stack for your app `heroku stack:set NEW-STACK`.

At this point "Stack" is still the old stack, but BuildStack is set to the new value. I think for building slugs the latter should be used.

If you think the change is right, would be awesome to get a new release too 🙌 

